### PR TITLE
Fix: 가격 변동 상승/하락 내림차순 최대 10개, 증감율로 넘기기(#11)

### DIFF
--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/IngredientGapService.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/IngredientGapService.java
@@ -1,16 +1,21 @@
 package com.cdd.recipeservice.ingredientmodule.weeklyprice.application;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.IntStream;
 
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import com.cdd.recipeservice.ingredientmodule.ingredient.domain.Ingredient;
+import com.cdd.recipeservice.global.utils.RedisUtils;
 import com.cdd.recipeservice.ingredientmodule.ingredient.domain.IngredientRepository;
+import com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.IngredientPriceGapList;
+import com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.IngredientSalesDailyPriceStat;
 import com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.IngredientSalesDailyPriceStatRepository;
 import com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response.IngredientPriceGap;
 import com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response.IngredientPriceGapResponse;
-import com.cdd.recipeservice.recipemodule.recipe.exception.RecipeErrorCode;
-import com.cdd.recipeservice.recipemodule.recipe.exception.RecipeException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,28 +24,88 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Service
 public class IngredientGapService {
+	private static final String KEY = "ingredient-price-gap-";
 	private final IngredientRepository ingredientRepository;
 	private final IngredientSalesDailyPriceStatRepository ingredientSalesDailyPriceStatRepository;
+	private final RedisTemplate<byte[], byte[]> redisTemplate;
+	private final ObjectMapper objectMapper;
 
 	public IngredientPriceGapResponse getAscGapList() {
-		List<IngredientPriceGap> responseList = ingredientSalesDailyPriceStatRepository.findIngredientDailyPrice(true);
-		for (IngredientPriceGap response : responseList) {
-			Ingredient ingredient = ingredientRepository.findById(response.getIngredientId())
-				.orElseThrow(() -> new RecipeException(RecipeErrorCode.NO_EXISTED_INGREDIENT));
-			response.updateInfo(ingredient.getName(), ingredient.getImg());
-		}
-		log.info("#####SVC ASC " + responseList.size());
-		return IngredientPriceGapResponse.from(responseList);
+		IngredientPriceGapList ingredientPriceGapList = RedisUtils.get(
+			redisTemplate,
+			objectMapper,
+			IngredientPriceGapList.class,
+			KEY, "asc"
+		);
+		return IngredientPriceGapResponse.from(ingredientPriceGapList);
 	}
 
 	public IngredientPriceGapResponse getDescGapList() {
-		List<IngredientPriceGap> responseList = ingredientSalesDailyPriceStatRepository.findIngredientDailyPrice(false);
-		for (IngredientPriceGap response : responseList) {
-			Ingredient ingredient = ingredientRepository.findById(response.getIngredientId())
-				.orElseThrow(() -> new RecipeException(RecipeErrorCode.NO_EXISTED_INGREDIENT));
-			response.updateInfo(ingredient.getName(), ingredient.getImg());
+		IngredientPriceGapList ingredientPriceGapList = RedisUtils.get(
+			redisTemplate,
+			objectMapper,
+			IngredientPriceGapList.class,
+			KEY, "desc"
+		);
+		return IngredientPriceGapResponse.from(ingredientPriceGapList);
+	}
+
+	@Scheduled(cron = "0 0 0 * * *")
+	public void saveIngredientPriceGap() {
+		LocalDate today = LocalDate.now();
+		List<IngredientSalesDailyPriceStat> todayList =
+			ingredientSalesDailyPriceStatRepository.findIngredientDailyPrice(today);
+		List<IngredientSalesDailyPriceStat> yesterdayList =
+			ingredientSalesDailyPriceStatRepository.findIngredientDailyPrice(
+				today.minusDays(1));
+
+		IngredientPriceGapList asc = new IngredientPriceGapList(KEY + "asc");
+		IngredientPriceGapList desc = new IngredientPriceGapList(KEY + "desc");
+		calculatePriceGap(todayList, yesterdayList, asc, desc);
+
+		RedisUtils.put(
+			redisTemplate,
+			objectMapper,
+			asc.sortAndLimit(10,1),
+			KEY + "asc");
+		RedisUtils.put(
+			redisTemplate,
+			objectMapper,
+			desc.sortAndLimit(10,-1),
+			KEY + "desc");
+	}
+
+	private void calculatePriceGap(
+		List<IngredientSalesDailyPriceStat> todayList,
+		List<IngredientSalesDailyPriceStat> yesterdayList,
+		IngredientPriceGapList asc,
+		IngredientPriceGapList desc
+	) {
+		IntStream.range(0, Math.min(todayList.size(), yesterdayList.size()))
+			.forEach(i -> {
+					double percent = calculatePercent(
+						todayList.get(i).getAvgPrice(),
+						yesterdayList.get(i).getAvgPrice()
+					);
+					IngredientPriceGap ingredientPriceGap = IngredientPriceGap.of(
+						todayList.get(i).getIngredient(),
+						percent
+					);
+
+					if (ingredientPriceGap.getPercent() > 0) {
+						asc.addGap(ingredientPriceGap);
+					} else if (ingredientPriceGap.getPercent() < 0) {
+						desc.addGap(ingredientPriceGap);
+					}
+				}
+			);
+	}
+
+	private double calculatePercent(int todayAvgPrice, int yesterdayAvgPrice) {
+		if (yesterdayAvgPrice != 0) {
+			double result = ((double)(todayAvgPrice - yesterdayAvgPrice) / yesterdayAvgPrice) * 100.0;
+			return Math.round(result * 100.0) / 100.0;
 		}
-		log.info("#####SVC ASC " + responseList.size());
-		return IngredientPriceGapResponse.from(responseList);
+		return 0.0;
 	}
 }

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/IngredientGapService.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/IngredientGapService.java
@@ -66,12 +66,12 @@ public class IngredientGapService {
 		RedisUtils.put(
 			redisTemplate,
 			objectMapper,
-			asc.sortAndLimit(10,1),
+			asc.sortAndLimit(10, 1),
 			KEY + "asc");
 		RedisUtils.put(
 			redisTemplate,
 			objectMapper,
-			desc.sortAndLimit(10,-1),
+			desc.sortAndLimit(10, -1),
 			KEY + "desc");
 	}
 
@@ -106,6 +106,6 @@ public class IngredientGapService {
 			double result = ((double)(todayAvgPrice - yesterdayAvgPrice) / yesterdayAvgPrice) * 100.0;
 			return Math.round(result * 100.0) / 100.0;
 		}
-		return 0.0;
+		return 0.0D;
 	}
 }

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientPriceGapList.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientPriceGapList.java
@@ -1,0 +1,44 @@
+package com.cdd.recipeservice.ingredientmodule.weeklyprice.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response.IngredientPriceGap;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@Builder
+@Getter
+@NoArgsConstructor
+@RedisHash(timeToLive = 60 * 60 * 24)
+public class IngredientPriceGapList {
+	@Id
+	String key;
+	@JsonProperty("ingredient_gap_list")
+	List<IngredientPriceGap> ingredientPriceGaps;
+
+	public IngredientPriceGapList(String key) {
+		this.key = key;
+		ingredientPriceGaps = new ArrayList<>();
+	}
+
+	public void addGap(IngredientPriceGap ingredientPriceGap) {
+		ingredientPriceGaps.add(ingredientPriceGap);
+	}
+
+	public IngredientPriceGapList sortAndLimit(int limit, int order) {
+		ingredientPriceGaps.sort((b, a) -> Double.compare(a.getPercent()*order, b.getPercent()*order));
+		if (ingredientPriceGaps.size() > limit) {
+			ingredientPriceGaps = ingredientPriceGaps.subList(0, limit);
+		}
+		return this;
+	}
+}

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientPriceGapList.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientPriceGapList.java
@@ -21,9 +21,9 @@ import lombok.NoArgsConstructor;
 @RedisHash(timeToLive = 60 * 60 * 24)
 public class IngredientPriceGapList {
 	@Id
-	String key;
+	private String key;
 	@JsonProperty("ingredient_gap_list")
-	List<IngredientPriceGap> ingredientPriceGaps;
+	private List<IngredientPriceGap> ingredientPriceGaps;
 
 	public IngredientPriceGapList(String key) {
 		this.key = key;
@@ -35,7 +35,7 @@ public class IngredientPriceGapList {
 	}
 
 	public IngredientPriceGapList sortAndLimit(int limit, int order) {
-		ingredientPriceGaps.sort((b, a) -> Double.compare(a.getPercent()*order, b.getPercent()*order));
+		ingredientPriceGaps.sort((b, a) -> Double.compare(a.getPercent() * order, b.getPercent() * order));
 		if (ingredientPriceGaps.size() > limit) {
 			ingredientPriceGaps = ingredientPriceGaps.subList(0, limit);
 		}

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/query/IngredientSalesDailyPriceStatRepositoryCustom.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/query/IngredientSalesDailyPriceStatRepositoryCustom.java
@@ -1,12 +1,12 @@
 package com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.query;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 import com.cdd.recipeservice.ingredientmodule.market.domain.MarketType;
 import com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.IngredientSalesDailyPriceStat;
 import com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.cond.PriceSearchCond;
-import com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response.IngredientPriceGap;
 
 public interface IngredientSalesDailyPriceStatRepositoryCustom {
 	List<IngredientSalesDailyPriceStat> findByIdTypeAndWeek(PriceSearchCond cond);
@@ -21,5 +21,5 @@ public interface IngredientSalesDailyPriceStatRepositoryCustom {
 
 	List<Integer> findOfflinePriceList(int ingredientId);
 
-	List<IngredientPriceGap> findIngredientDailyPrice(boolean asc);
+	List<IngredientSalesDailyPriceStat> findIngredientDailyPrice(LocalDate day);
 }

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/dto/response/IngredientPriceGap.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/dto/response/IngredientPriceGap.java
@@ -1,12 +1,17 @@
 package com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response;
 
+import com.cdd.recipeservice.ingredientmodule.ingredient.domain.Ingredient;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@AllArgsConstructor
 @Getter
 @Builder
+@NoArgsConstructor
 public class IngredientPriceGap {
 	@JsonProperty("ingredient_id")
 	private int ingredientId;
@@ -14,23 +19,17 @@ public class IngredientPriceGap {
 	private String ingredientName;
 	@JsonProperty("ingredient_image")
 	private String ingredientImage;
+	@JsonProperty("percent")
+	private double percent;
 
-	@JsonProperty("prev_price")
-	private int prevPrice;
-	@JsonProperty("curr_price")
-	private int currPrice;
-
-	public IngredientPriceGap(int ingredientId, String ingredientName, String ingredientImage, int prevPrice,
-		int currPrice) {
-		this.ingredientId = ingredientId;
-		this.ingredientName = ingredientName;
-		this.ingredientImage = ingredientImage;
-		this.prevPrice = prevPrice;
-		this.currPrice = currPrice;
-	}
-
-	public void updateInfo(String ingredientName, String ingredientImage) {
-		this.ingredientName = ingredientName;
-		this.ingredientImage = ingredientImage;
+	public static IngredientPriceGap of(
+		Ingredient ingredient,
+		double percent) {
+		return IngredientPriceGap.builder()
+			.ingredientId(ingredient.getId())
+			.ingredientName(ingredient.getName())
+			.ingredientImage(ingredient.getImg())
+			.percent(percent)
+			.build();
 	}
 }

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/dto/response/IngredientPriceGapResponse.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/dto/response/IngredientPriceGapResponse.java
@@ -2,6 +2,7 @@ package com.cdd.recipeservice.ingredientmodule.weeklyprice.dto.response;
 
 import java.util.List;
 
+import com.cdd.recipeservice.ingredientmodule.weeklyprice.domain.IngredientPriceGapList;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Builder;
@@ -11,9 +12,9 @@ public record IngredientPriceGapResponse(
 	@JsonProperty("ingredient_gap_list")
 	List<IngredientPriceGap> ingredientPriceGapList
 ) {
-	public static IngredientPriceGapResponse from(List<IngredientPriceGap> ingredientPriceGapList){
+	public static IngredientPriceGapResponse from(IngredientPriceGapList ingredientPriceGapList){
 		return IngredientPriceGapResponse.builder()
-			.ingredientPriceGapList(ingredientPriceGapList)
+			.ingredientPriceGapList(ingredientPriceGapList.getIngredientPriceGaps())
 			.build();
 	}
 }

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/presentation/IngredientGapController.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/presentation/IngredientGapController.java
@@ -2,6 +2,7 @@ package com.cdd.recipeservice.ingredientmodule.weeklyprice.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,15 +23,19 @@ public class IngredientGapController {
 
 	@GetMapping("/v1/ingredients/rank/asc")
 	public ResponseEntity<MessageBody<IngredientPriceGapResponse>> getAscGapList() {
-		IngredientPriceGapResponse ingredientGapResponse = ingredientGapService.getAscGapList();
-		log.info("#####CTRL ASC " + ingredientGapResponse.ingredientPriceGapList().size());
-		return ResponseEntityFactory.ok("가격 변동 상승 정보 조회 성공", ingredientGapResponse);
+		IngredientPriceGapResponse response = ingredientGapService.getAscGapList();
+		return ResponseEntityFactory.ok("가격 변동 상승 정보 조회 성공", response);
 	}
 
 	@GetMapping("/v1/ingredients/rank/desc")
 	public ResponseEntity<MessageBody<IngredientPriceGapResponse>> getDescGapList() {
-		IngredientPriceGapResponse ingredientGapResponse = ingredientGapService.getDescGapList();
-		log.info("#####CTRL DESC " + ingredientGapResponse.ingredientPriceGapList().size());
-		return ResponseEntityFactory.ok("가격 변동 하락 정보 조회 성공", ingredientGapResponse);
+		IngredientPriceGapResponse response = ingredientGapService.getDescGapList();
+		return ResponseEntityFactory.ok("가격 변동 하락 정보 조회 성공", response);
+	}
+
+	@PostMapping("/v1/ingredients/rank")
+	public ResponseEntity<MessageBody<Void>> saveIngredientPriceGap() {
+		ingredientGapService.saveIngredientPriceGap();
+		return ResponseEntityFactory.ok("가격 변동 정보 저장 성공");
 	}
 }


### PR DESCRIPTION
## 📑 개요

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

프론트엔드에서 오늘의 가격, 어제의 가격 차이를 계산하는 방식을 백엔드에서 퍼센트만 넘기기로 변경
최대 10개 까지
증감율 내림차순으로

### ✅ PR 체크리스트

---

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

### 🚀 상세 작업 내용

- 하루동안 식재료 가격 증감율 캐싱으로 조회api 속도 개선
- cur, pre price로 넘기는 responsebody대신 percent 계산해서 넘기도록 비지니스로직 구현
---

<!-- 상세 작업 내용 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

### 📁 ETC

---

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을
입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->
