### PR TITLE
Fix: 데이터가 캐싱된 시간 updateAt 넘기기(#18)

### DIFF
--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/application/RecommendIngredientServiceImpl.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/application/RecommendIngredientServiceImpl.java
@@ -27,13 +27,13 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @Service
 public class RecommendIngredientServiceImpl implements RecommendIngredientService {
+	private final IngredientRepository ingredientRepository;
+	private final RedisTemplate<byte[], byte[]> redisTemplate;
+	private final ObjectMapper objectMapper;
 	@Value("${ingredient.max-size}")
 	private int maxResults;
 	@Value("${ingredient.key}")
 	private String recommendIngredientKey;
-	private final IngredientRepository ingredientRepository;
-	private final RedisTemplate<byte[], byte[]> redisTemplate;
-	private final ObjectMapper objectMapper;
 
 	@Override
 	public List<RecommendIngredient> selectRecommendIngredient(

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/domain/RecommendIngredient.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/domain/RecommendIngredient.java
@@ -1,5 +1,6 @@
 package com.cdd.recipeservice.ingredientmodule.ingredient.domain;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.redis.core.RedisHash;
@@ -24,11 +25,14 @@ import lombok.NoArgsConstructor;
 public class RecommendIngredient {
 	@Id
 	private String key;
+	@JsonProperty("updatedAt")
+	private LocalDateTime updatedAt;
 	@JsonProperty("ingredients")
 	private Ingredients ingredients;
 
 	public static RecommendIngredient from(Ingredient ingredient) {
 		return RecommendIngredient.builder()
+			.updatedAt(LocalDateTimeUtils.today("Asia/Seoul"))
 			.ingredients(Ingredients.builder()
 				.id(ingredient.getId())
 				.name(ingredient.getName())

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/dto/response/IngredientInfo.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/ingredient/dto/response/IngredientInfo.java
@@ -24,7 +24,7 @@ public class IngredientInfo {
 
 	public static IngredientInfo from(List<RecommendIngredient> recommendIngredient) {
 		return IngredientInfo.builder()
-			.updateAt(LocalDateTimeUtils.nowTimePattern("Asia/Seoul"))
+			.updateAt(LocalDateTimeUtils.timePattern(recommendIngredient.get(0).getUpdatedAt()))
 			.ingredients(recommendIngredient)
 			.build();
 	}


### PR DESCRIPTION
## 📑 개요

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

#18 
### ✅ PR 체크리스트

---

- [ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ] 💯 테스트는 잘 통과했나요?
- [ ] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

### 🚀 상세 작업 내용

---

<!-- 상세 작업 내용 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

[X] 데이터를 캐싱하는 시간도 함께 저장
[X] 데이터 조회시 캐싱한 시간을 updateAt넘기기

### 📁 ETC

---

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을
입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->
