### PR TITLE
주간 데이터 저장시 데이터가 캐싱된 시간 updateAt 넘기기(#22)

### DIFF
--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/market/dto/response/MarketPricePerUserResponse.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/market/dto/response/MarketPricePerUserResponse.java
@@ -1,7 +1,6 @@
 package com.cdd.recipeservice.ingredientmodule.market.dto.response;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,12 +27,13 @@ public class MarketPricePerUserResponse {
 	private List<Map<Integer, List<WeeklyPrice>>> marketPriceList;
 
 	public static <T extends MarketInfoMaker> MarketPricePerUserResponse of(
+		LocalDateTime updatedAt,
 		int targetPrice,
 		int todayMinimumPrice,
 		List<T> markets,
-		List<Map<Integer, List<WeeklyPrice>>> weeklyPriceList){
+		List<Map<Integer, List<WeeklyPrice>>> weeklyPriceList) {
 		MarketPricePerUserResponse marketPricePerUserResponse = MarketPricePerUserResponse.builder()
-			.updateAt(LocalDateTimeUtils.timePattern(LocalDateTime.now(ZoneId.of("Asia/Seoul"))))
+			.updateAt(LocalDateTimeUtils.timePattern(updatedAt))
 			.targetPrice(targetPrice)
 			.todayMinimumPrice(todayMinimumPrice)
 			.marketType(new ArrayList<>())

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/MarketIngredientWeeklyPriceService.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/application/MarketIngredientWeeklyPriceService.java
@@ -1,5 +1,6 @@
 package com.cdd.recipeservice.ingredientmodule.weeklyprice.application;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -94,7 +95,16 @@ public class MarketIngredientWeeklyPriceService {
 				unit);
 			marketPriceList.add(weeklyAvgPrices);
 		}
+
+		LocalDateTime updatedAt = RedisUtils.get(
+			redisTemplate,
+			objectMapper,
+			IngredientWeeklyPrice.class,
+			"offline", "-", ingredientId
+		).getUpdateAt();
+
 		return MarketPricePerUserResponse.of(
+			updatedAt,
 			targetPrice,
 			todayMinimumPrice,
 			closestMarkets,
@@ -169,7 +179,15 @@ public class MarketIngredientWeeklyPriceService {
 			);
 			marketPriceList.add(weeklyAvgPrices);
 		}
+		LocalDateTime updatedAt = RedisUtils.get(
+			redisTemplate,
+			objectMapper,
+			IngredientWeeklyPrice.class,
+			"online", "-", ingredientId
+		).getUpdateAt();
+
 		return MarketPricePerUserResponse.of(
+			updatedAt,
 			targetPrice,
 			todayMinimumPrice,
 			onlineMarkets,

--- a/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientWeeklyPrice.java
+++ b/src/main/java/com/cdd/recipeservice/ingredientmodule/weeklyprice/domain/IngredientWeeklyPrice.java
@@ -1,9 +1,11 @@
 package com.cdd.recipeservice.ingredientmodule.weeklyprice.domain;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 import org.springframework.data.redis.core.*;
 
+import com.cdd.recipeservice.global.utils.LocalDateTimeUtils;
 import com.fasterxml.jackson.annotation.*;
 
 import jakarta.persistence.*;
@@ -17,14 +19,18 @@ import lombok.*;
 public class IngredientWeeklyPrice {
 	@Id
 	private String key;
+	@JsonProperty("updatedAt")
+	private LocalDateTime updateAt;
 	@JsonProperty("weekly_prices")
 	private Map<Integer, List<WeeklyPrice>> weeklyPrices;
 
 	public static IngredientWeeklyPrice of(String type,
 		int id,
-		Map<Integer, List<WeeklyPrice>> weeklyPrices) {
+		Map<Integer, List<WeeklyPrice>> weeklyPrices
+	) {
 		return IngredientWeeklyPrice.builder()
 			.key(type + "-" + id)
+			.updateAt(LocalDateTimeUtils.today("Asia/Seoul"))
 			.weeklyPrices(weeklyPrices)
 			.build();
 	}


### PR DESCRIPTION
## 📑 개요

<!-- 개요에는 왜 이 작업을 했는지 알려주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- #(해당 이슈 번호) -->
<!-- 중복 회원 가입 방지 기능 구현 -->
<!-- Assignees 에는 자신과 참여를 원 하시는 분을 선택하시면 됩니다! -->

#22 
온/오프라인 주간 가격 추이를 업데이트 날짜가 새로고침할때마다 바뀜
가격 추이 데이터가 업데이트된 날짜로 고정

### ✅ PR 체크리스트

---

- [x] 🔀 PR 제목의 형식을 잘 작성했나요?
- [x] 💯 테스트는 잘 통과했나요?
- [x] 🏗️ 빌드는 성공했나요?
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

### 🚀 상세 작업 내용

---

<!-- 상세 작업 내용 에서는 어떠한 작업을 했는지 상세히 적어주세요! -->

<!-- 예시는 다음과 같습니다. -->
<!-- - [X] 아이디 중복 검사 비즈니스 로직 구현 -->
<!-- - [X] 중복일 경우 예외 처리 기능 구현 -->

- [x]  가격 추이 계산 후 스케쥴러가 실행된 시간 저장
- [x]  해당 가격추이 그래프를 조회할 경우 스케쥴러가 실행된 시간으로 updateAt 변경

### 📁 ETC

---

<!-- 이 곳에서는 관련 자료나 사진을 올여주세요! -->
<!-- 링크를 넣고 싶은 경우에는 MAC 에서는 커맨드 + K, Windows 에서는 컨트롤 + K를 누르면 [](url) 가 생성되는데 [] 안에는 원하시는 링크의 제목을 입력하고 () 안에는 URL을
입력해주세요! -->
<!-- 사진 같은 경우에는 drag and drop 으로 사진을 추가할 수 있습니다! -->
